### PR TITLE
Only extract the Title in the HEAD element

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,7 +43,7 @@ function getTitle(doc: cheerio.Root) {
     metaTagContent(doc, `og:title`, `property`) ||
     metaTagContent(doc, `og:title`, `name`);
   if (!title) {
-    title = doc(`title`).text();
+    title = doc(`head > title`).text();
   }
   return title;
 }


### PR DESCRIPTION
Without this fix all Title elements within the HTML are concatenated together. SVG elements can contain a Title element. This fix restricts the title to be the page title in the HEAD element.