### PR TITLE
fallback to abort-controller polyfill

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -404,7 +404,7 @@ export async function getLinkPreview(
   }
 
   const timeout = options?.timeout ?? 3000; // 3 second timeout default
-  const controller = new (AbortController || AbortControllerPolyfill)();
+  const controller = createAbortController();
   const timeoutCounter = setTimeout(() => controller.abort(), timeout);
 
   const fetchOptions = {
@@ -487,4 +487,11 @@ export async function getPreviewFromContent(
   }
 
   return parseResponse(response, options);
+}
+
+
+function createAbortController(): AbortController | AbortControllerPolyfill {
+  return typeof AbortController == 'undefined'
+    ? new AbortControllerPolyfill()
+    : new AbortController();
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import cheerio from "cheerio";
 import { fetch } from "cross-fetch";
-import AbortController from "abort-controller";
+import AbortControllerPolyfill from "abort-controller";
 import urlObj from "url";
 import { CONSTANTS } from "./constants";
 
@@ -404,7 +404,7 @@ export async function getLinkPreview(
   }
 
   const timeout = options?.timeout ?? 3000; // 3 second timeout default
-  const controller = new AbortController();
+  const controller = new (AbortController || AbortControllerPolyfill)();
   const timeoutCounter = setTimeout(() => controller.abort(), timeout);
 
   const fetchOptions = {


### PR DESCRIPTION
The abort-controller package doesn't really act as a polyfill to AbortController. Therefore, we're falling back to the package if the AbortController is not available 