### PR TITLE
feat: drop uneeded polyfills

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -214,7 +214,7 @@ describe(`#getLinkPreview()`, () => {
       await getLinkPreview(`http://google.com/`, { followRedirects: `error` });
     } catch (e: any) {
       expect(e.message).toEqual(
-        `uri requested responds with a redirect, redirect mode is set to error: http://google.com/`
+        `fetch failed`
       );
     }
   });

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,4 @@
 import cheerio from "cheerio";
-import { fetch } from "cross-fetch";
-import AbortControllerPolyfill from "abort-controller";
 import urlObj from "url";
 import { CONSTANTS } from "./constants";
 
@@ -404,7 +402,7 @@ export async function getLinkPreview(
   }
 
   const timeout = options?.timeout ?? 3000; // 3 second timeout default
-  const controller = createAbortController();
+  const controller = new AbortController();
   const timeoutCounter = setTimeout(() => controller.abort(), timeout);
 
   const fetchOptions = {
@@ -489,9 +487,3 @@ export async function getPreviewFromContent(
   return parseResponse(response, options);
 }
 
-
-function createAbortController(): AbortController | AbortControllerPolyfill {
-  return typeof AbortController == 'undefined'
-    ? new AbortControllerPolyfill()
-    : new AbortController();
-}

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "license": "MIT",
   "repository": "https://github.com/ospfranco/link-preview-js",
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "cheerio": "1.0.0-rc.11",
-    "cross-fetch": "3.1.5",
     "url": "0.11.0"
   },
   "files": [
@@ -47,5 +45,8 @@
     "ts-jest": "^28.0.5",
     "typescript": "^4.7.4"
   },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,13 +799,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
@@ -1104,13 +1097,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cross-fetch@3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -1239,11 +1225,6 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -1986,13 +1967,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -2400,11 +2374,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
 ts-jest@^28.0.5:
   version "28.0.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.5.tgz#31776f768fba6dfc8c061d488840ed0c8eeac8b9"
@@ -2470,19 +2439,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Removes polyfills that are no longer needed.

AbortController has been supported since Node v14, which reached it's EOL in 2021.

`fetch` API has been supported since Node v18, which will reach it's EOL in 30.04.2025 and has been there for 3 years, so it is safe to drop the dependency.