### PR TITLE
replaced url package with URL constructor

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import cheerio from "cheerio";
-import urlObj from "url";
 import { CONSTANTS } from "./constants";
 
 interface ILinkPreviewOptions {
@@ -93,7 +92,7 @@ function getImages(
       if (node.type === `tag`) {
         src = node.attribs.content;
         if (src) {
-          src = urlObj.resolve(rootUrl, src);
+          src = new URL(src, rootUrl).toString();
           images.push(src);
         }
       }
@@ -103,7 +102,7 @@ function getImages(
   if (images.length <= 0 && !imagesPropertyType) {
     src = doc(`link[rel=image_src]`).attr(`href`);
     if (src) {
-      src = urlObj.resolve(rootUrl, src);
+      src = new URL(src, rootUrl).toString();
       images = [src];
     } else {
       nodes = doc(`img`);
@@ -117,7 +116,7 @@ function getImages(
             dic[src] = true;
             // width = node.attribs.width;
             // height = node.attribs.height;
-            images.push(urlObj.resolve(rootUrl, src));
+            images.push(new URL(src, rootUrl).toString());
           }
         });
       }
@@ -192,7 +191,7 @@ function getVideos(doc: cheerio.Root) {
 
 // returns default favicon (//hostname/favicon.ico) for a url
 function getDefaultFavicon(rootUrl: string) {
-  return urlObj.resolve(rootUrl, `/favicon.ico`);
+  return new URL(`/favicon.ico`, rootUrl).toString();
 }
 
 // returns an array of URLs to favicon images
@@ -216,7 +215,7 @@ function getFavicons(doc: cheerio.Root, rootUrl: string) {
       nodes.each((_: number, node: cheerio.Element) => {
         if (node.type === `tag`) src = node.attribs.href;
         if (src) {
-          src = urlObj.resolve(rootUrl, src);
+          src = new URL(src, rootUrl).toString();
           images.push(src);
         }
       });
@@ -486,4 +485,3 @@ export async function getPreviewFromContent(
 
   return parseResponse(response, options);
 }
-

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "license": "MIT",
   "repository": "https://github.com/ospfranco/link-preview-js",
   "dependencies": {
-    "cheerio": "1.0.0-rc.11",
-    "url": "0.11.0"
+    "cheerio": "1.0.0-rc.11"
   },
   "files": [
     "build"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,16 +2124,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
 react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
@@ -2415,14 +2405,6 @@ update-browserslist-db@^1.0.4:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
-
-url@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
This PR solved #149 by replacing `url` dependency with the native URL() constructor.

This constructor supports by Node.js since v6.13 https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
The minimum Node.js version is 18 according to package.json requirements. 

