### PR TITLE
Correctly parse relative URIs in manually handled redirects #168

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -433,7 +433,7 @@ export async function getLinkPreview(
     options?.handleRedirects
   ) {
     const locationHeader = response.headers.get(`location`) || ``;
-	const isAbsoluteURI = locationHeader.startsWith('http://') || locationHeader.startsWith('https://'); 
+    const isAbsoluteURI = locationHeader.startsWith('http://') || locationHeader.startsWith('https://'); 
 
     // Resolve the URL, handling both absolute and relative URLs
     const forwardedUrl = isAbsoluteURI
@@ -492,3 +492,4 @@ export async function getPreviewFromContent(
 
   return parseResponse(response, options);
 }
+

--- a/index.ts
+++ b/index.ts
@@ -432,7 +432,13 @@ export async function getLinkPreview(
     fetchOptions.redirect === `manual` &&
     options?.handleRedirects
   ) {
-    const forwardedUrl = response.headers.get(`location`) || ``;
+    const locationHeader = response.headers.get(`location`) || ``;
+	const isAbsoluteURI = locationHeader.startsWith('http://') || locationHeader.startsWith('https://'); 
+
+    // Resolve the URL, handling both absolute and relative URLs
+    const forwardedUrl = isAbsoluteURI
+      ? locationHeader
+      : urlObj.resolve(fetchUrl, locationHeader);
 
     if (!options.handleRedirects(fetchUrl, forwardedUrl)) {
       throw new Error(`link-preview-js could not handle redirect`);
@@ -486,4 +492,3 @@ export async function getPreviewFromContent(
 
   return parseResponse(response, options);
 }
-


### PR DESCRIPTION
This detects if the destination value is a relative URI, and if so, it applies it to the originating fetch URI.

This will resolve Issue #168 