### PR TITLE
Resolves OP-Engineering/link-preview-js#159 - Creates an onResponse c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Additionally, you can pass an options object which should add more functionality
 | followRedirects (**optional**) (default 'error')                                       | For security reasons, the library does not automatically follow redirects ('error' value), a malicious agent can exploit redirects to steal data, posible values: ('error', 'follow', 'manual') |
 | handleRedirects (**optional**) (with followRedirects 'manual')                         |                         When followRedirects is set to 'manual' you need to pass a function that validates if the redirectinon is secure, below you can find an example                         |
 | resolveDNSHost (**optional**)                                                          |                                                   Function that resolves the final address of the detected/parsed URL to prevent SSRF attacks                                                   |
+| onResponse (**optional**)                                                          |                                                   Function that handles the response object to allow for managing special cases                                                   |
 
 ```javascript
 getLinkPreview("https://www.youtube.com/watch?v=MejbOFk7H6c", {
@@ -155,6 +156,25 @@ await getLinkPreview(`http://google.com/`, {
     } else {
       return false;
     }
+  },
+});
+```
+
+## onResponse Use Cases
+There may be situations where you need to provide your own logic for population properties in the response object. For example, if the library is unable to detect a description because the website does not provide OpenGraph data, you might want to use the text value of the first paragraph instead. This callback gives you access to the Cheerio doc instance, as well as the URL object so you could handle cases on a site-by-site basis, if you need to. This callback must return the modified response object
+
+```javascript
+await getLinkPreview(`https://example.com/`, {
+  onResponse: (response, doc, URL) => {
+    if (URL.hostname == 'example.com') {
+        response.siteName = 'Example Website';
+    }
+
+    if (!response.description) {
+      response.description = doc('p').first().text();
+    }
+    
+    return response;
   },
 });
 ```

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -243,6 +243,23 @@ describe(`#getLinkPreview()`, () => {
     expect(response.mediaType).toEqual(`website`);
   });
 
+  it("should handle override response body using onResponse option", async () => {	
+    let firstParagraphText;
+
+    const res: any = await getLinkPreview(`https://www.example.com/`, { 
+      onResponse: (result, doc) => {
+        firstParagraphText = doc('p').first().text().split('\n').map(x=> x.trim()).join(' ');
+        result.siteName = `SiteName has been overridden`;
+        result.description = firstParagraphText;
+
+        return result;
+      }
+    });
+
+    expect(res.siteName).toEqual("SiteName has been overridden");
+	  expect(res.description).toEqual(firstParagraphText);
+  });
+
   it("should handle video tags without type or secure_url tags", async () => {
     const res: any = await getLinkPreview(
       `https://newpathtitle.com/falling-markets-how-to-stop-buyer-from-getting-out/`,

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -257,7 +257,7 @@ describe(`#getLinkPreview()`, () => {
     });
 
     expect(res.siteName).toEqual("SiteName has been overridden");
-	  expect(res.description).toEqual(firstParagraphText);
+    expect(res.description).toEqual(firstParagraphText);
   });
 
   it("should handle video tags without type or secure_url tags", async () => {


### PR DESCRIPTION
This PR: 

- Creates the optional `onResponse ` option that is a callback function that allows the developer to modify the contents of the parsed response body, in the event there needs to be custom logic or sources for different properties. For example, say the targeted website does not provide opengraph description, the developer might want to instead have the description be the text contents of the first p tag. Additionally, an instance of the URL object has been exposed so the callback could contain site-by-site considerations.
- Creates a test for onResponse functionality.
- Updates README to provide documentation and use case for onResponse
- Defines Type `ILinkPreviewResponse `  for the actual library response for type safety.

Tests passed locally (Github CI tests might break due to bot detection)

This PR will resolve #159 